### PR TITLE
Fix invalid ado net sql injection example

### DIFF
--- a/Chapter02/sql-injection/razor/ado.net/after/OnlineBankingApp/Data/FundTransferDAL.cs
+++ b/Chapter02/sql-injection/razor/ado.net/after/OnlineBankingApp/Data/FundTransferDAL.cs
@@ -55,7 +55,7 @@ namespace OnlineBankingApp.Data
   
             using (SqliteConnection con = new SqliteConnection(connectionString))  
             {  
-                SqliteCommand cmd = new SqliteCommand("Select * from FundTransfer where Note like '%" + @search + "%'", con);  
+                SqliteCommand cmd = new SqliteCommand("Select * from FundTransfer where Note like '%@search%'", con);  
                 cmd.CommandType = CommandType.Text;  
   
                 cmd.Parameters.AddWithValue("@search", search);  


### PR DESCRIPTION
There is an issue in the corrected solution for the ado net sql injection example.

The problem is that the sql injection isn't fixed, the sql parameter is unused as the sql command text is invalid.
The old code simply concats the value of the search parameter and not the parametername "search" into the sql commandtext.
