### PR TITLE
Fix invalid ado net sql injection example

### DIFF
--- a/Chapter02/sql-injection/razor/ado.net/after/OnlineBankingApp/Data/FundTransferDAL.cs
+++ b/Chapter02/sql-injection/razor/ado.net/after/OnlineBankingApp/Data/FundTransferDAL.cs
@@ -55,10 +55,10 @@ namespace OnlineBankingApp.Data
   
             using (SqliteConnection con = new SqliteConnection(connectionString))  
             {  
-                SqliteCommand cmd = new SqliteCommand("Select * from FundTransfer where Note like '%" + @search + "%'", con);  
+                SqliteCommand cmd = new SqliteCommand("Select * from FundTransfer where Note like @search", con);  
                 cmd.CommandType = CommandType.Text;  
   
-                cmd.Parameters.AddWithValue("@search", search);  
+                cmd.Parameters.AddWithValue("@search", $"%{search}%"); 
 
                 con.Open();  
                 SqliteDataReader rdr = cmd.ExecuteReader();  


### PR DESCRIPTION
There is an issue in the corrected solution for the ado net sql injection example.

The problem is that the sql injection isn't fixed, the sql parameter is unused as the sql command text is invalid.
The old code simply concats the value of the search parameter and not the parametername "search" into the sql commandtext.

My first proposal / first pr fixed the sql injection, but on the other hand the was no longer any data returned.
I amended the commit to fix this and it looks like I'm not able to reopen the old one.
